### PR TITLE
Load default options in demo

### DIFF
--- a/docs/demo/demo.js
+++ b/docs/demo/demo.js
@@ -48,6 +48,8 @@ if ('text' in search) {
 
 if ('options' in search) {
   $optionsElem.value = search.options;
+} else {
+  $optionsElem.value = JSON.stringify(marked.getDefaults(), null, ' ');
 }
 
 if (search.outputType) {


### PR DESCRIPTION
Per @styfle's suggestion, setting the options element's contents to the defaults on load.